### PR TITLE
Complete User story 29: sad path message if shelter create form lacks fields

### DIFF
--- a/app/controllers/shelters_controller.rb
+++ b/app/controllers/shelters_controller.rb
@@ -20,15 +20,13 @@ class SheltersController < ApplicationController
   end
 
   def create
-    shelter = Shelter.new({
-                          name:     params[:name],
-                          address:  params[:address],
-                          city:     params[:city],
-                          state:    params[:state],
-                          zip:      params[:zip]
-                         })
-    shelter.save
-    redirect_to '/shelters'
+    shelter = Shelter.new(shelter_params)
+    if shelter.save
+      redirect_to '/shelters'
+    else
+      flash[:incomplete] = "You attempted to submit the form without completing required field(s): #{empty_params}"
+      redirect_to '/shelters/new'
+    end
   end
 
   def edit
@@ -37,13 +35,7 @@ class SheltersController < ApplicationController
 
   def update
     shelter = Shelter.find(params[:id])
-    shelter.update({
-                    name:     params[:name],
-                    address:  params[:address],
-                    city:     params[:city],
-                    state:    params[:state],
-                    zip:      params[:zip]
-                   })
+    shelter.update(shelter_params)
     shelter.save
     redirect_to "/shelters/#{shelter.id}"
   end
@@ -66,4 +58,17 @@ class SheltersController < ApplicationController
       @show_all = "active_sort"
     end
   end
+
+  private
+
+    def shelter_params
+      params.permit(:name, :address, :city, :state, :zip)
+    end
+
+    def empty_params
+      shelter_params.to_h.reduce("") do |empty_params,(key, value)|
+        next empty_params if value != ""
+        empty_params.empty? ? empty_params += key.capitalize : empty_params += ', ' + key.capitalize
+      end
+    end
 end

--- a/spec/features/shelters/user_can_create_new_shelters_spec.rb
+++ b/spec/features/shelters/user_can_create_new_shelters_spec.rb
@@ -39,4 +39,26 @@ RSpec.describe "shelter creation page", type: :feature do
     expect(current_path).to eq('/shelters')
     expect(page).to have_content("Ridiculous Test Name 2")
   end
+
+  it "displays flash message saying which fields are not filled if they're empty" do
+    visit 'shelters/new'
+
+    fill_in 'Address', with: "125 Fake Ln."
+    fill_in 'City', with: "Faketown"
+    fill_in 'State', with: "FK"
+    fill_in 'Zip', with: "55555"
+
+    click_button 'Submit'
+
+    expect(current_path).to eq('/shelters/new')
+    expect(page).to have_content("You attempted to submit the form without completing required field(s): Name")
+
+    fill_in 'City', with: "Faketown"
+    fill_in 'State', with: "FK"
+    fill_in 'Zip', with: "55555"
+
+    click_button 'Submit'
+
+    expect(page).to have_content("You attempted to submit the form without completing required field(s): Name, Address")
+  end
 end


### PR DESCRIPTION
Finished in 3.27 seconds (files took 2.3 seconds to load)
161 examples, 0 failures


Coverage report generated for RSpec to /Users/dframpton/turing/2module/group_projects/adopt_d
ont_shop/coverage. 1433 / 1433 LOC (100.0%) covered.