### PR TITLE
Complete User story 34: pet name always links to that pet's show page

### DIFF
--- a/app/views/applications/new.html.erb
+++ b/app/views/applications/new.html.erb
@@ -7,7 +7,9 @@
     <h3> Select favorited pets you wish to adopt </h3>
     <%= form_tag '/applications' do %>
       <% @favorited_pets.each do |favorite| %>
-        <%= label_tag favorite.id, favorite.name %>
+        <%= label_tag favorite.id do %>
+          <%= link_to favorite.name, "/pets/#{favorite.id}" %>
+        <% end %>
         <%= check_box_tag 'favorite_ids[]', favorite.id, false, :id => "checkbox-#{favorite.id}" %>
       <% end %>
       <%= label_tag :name %>

--- a/spec/features/pets/user_can_view_pet_by_name_link_spec.rb
+++ b/spec/features/pets/user_can_view_pet_by_name_link_spec.rb
@@ -62,5 +62,15 @@ RSpec.describe "As a visitor", type: :feature do
 
       expect(current_path).to eq("/pets/#{@pet_1.id}")
     end
+
+    it "on the new application form that link takes me to that pet's show page" do
+      visit "/pets/#{@pet_1.id}"
+      click_on "Favorite This Pet"
+
+      visit "/applications/new"
+      click_link("#{@pet_1.name}")
+
+      expect(current_path).to eq("/pets/#{@pet_1.id}")
+    end
   end
 end

--- a/spec/features/pets/user_can_view_pet_by_name_link_spec.rb
+++ b/spec/features/pets/user_can_view_pet_by_name_link_spec.rb
@@ -68,6 +68,18 @@ RSpec.describe "As a visitor", type: :feature do
       click_on "Favorite This Pet"
 
       visit "/applications/new"
+
+      click_link("#{@pet_1.name}")
+
+      expect(current_path).to eq("/pets/#{@pet_1.id}")
+    end
+
+    it "on the favorites page that link takes me to that pet's show page" do
+      visit "/pets/#{@pet_1.id}"
+      click_on "Favorite This Pet"
+
+      visit "/favorites"
+
       click_link("#{@pet_1.name}")
 
       expect(current_path).to eq("/pets/#{@pet_1.id}")


### PR DESCRIPTION
Tested locally. 

Finished in 4.28 seconds (files took 2.35 seconds to load)
176 examples, 0 failures

Coverage report generated for RSpec to /Users/dframpton/turing/2module/group_projects/adopt
_dont_shop/coverage. 1652 / 1652 LOC (100.0%) covered.