### PR TITLE
Complete User story 38: default image on reviews if none provided

### DIFF
--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -37,7 +37,7 @@ class ReviewsController < ApplicationController
 
   private
   def review_params
-    params.delete(:image_path) if params[:image_path].empty? 
+    params.delete(:image_path) if params[:image_path].empty?
     params.permit(:title, :rating, :content, :image_path)
   end
 end

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -37,6 +37,7 @@ class ReviewsController < ApplicationController
 
   private
   def review_params
+    params.delete(:image_path) if params[:image_path].empty? 
     params.permit(:title, :rating, :content, :image_path)
   end
 end

--- a/app/views/reviews/new.html.erb
+++ b/app/views/reviews/new.html.erb
@@ -13,6 +13,7 @@
       <%= text_field_tag :content %> <br/>
       <%= label_tag :image_path, 'Image Path' %>
       <%= url_field_tag :image_path %> <br/>
+      <%= label_tag :submit, "" %>
       <%= submit_tag 'Submit' %>
     <% end %>
   </section>

--- a/db/migrate/20191203043958_create_reviews.rb
+++ b/db/migrate/20191203043958_create_reviews.rb
@@ -4,7 +4,7 @@ class CreateReviews < ActiveRecord::Migration[5.1]
       t.string :title
       t.integer :rating
       t.string :content
-      t.string :image_path
+      t.string :image_path, default: "https://www.cityofdenton.com/CoD/media/City-of-Denton/Interior%20General%20Content%20Images/6L1A6931-500x333.jpg"
       t.timestamps
       t.references :shelter, foreign_key: true
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -52,7 +52,7 @@ ActiveRecord::Schema.define(version: 20191207225436) do
     t.string "title"
     t.integer "rating"
     t.string "content"
-    t.string "image_path"
+    t.string "image_path", default: "https://www.cityofdenton.com/CoD/media/City-of-Denton/Interior%20General%20Content%20Images/6L1A6931-500x333.jpg"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "shelter_id"

--- a/spec/features/reviews/user_sees_default_shelter_review_image_spec.rb
+++ b/spec/features/reviews/user_sees_default_shelter_review_image_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+# User Story 38, Reviews have a default picture
+
+RSpec.describe 'As a visitor', type: :feature do
+  describe 'When I create a review for a shelter' do
+    describe 'And do not fill in the field for an image' do
+      it 'A default image is used and displayed for that review upon submission' do
+        shelter = Shelter.create(name: "Doggy Dreamland",
+                                   address: "124 Fake Ln.",
+                                   city: "Faketown",
+                                   state: "FK",
+                                   zip: "55555")
+
+        visit "/shelters/#{shelter.id}/reviews/new"
+
+        fill_in 'Title', with: "Great Location, but..."
+        fill_in 'Rating', with: 4
+        fill_in 'Content', with: "Smells like dog!"
+
+        click_on 'Submit'
+
+        within "#review-#{shelter.reviews.last.id}" do
+          expect(page).to have_css("img[src='https://www.cityofdenton.com/CoD/media/City-of-Denton/Interior%20General%20Content%20Images/6L1A6931-500x333.jpg']")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Tested locally.

RSpec results:
```
Finished in 4.95 seconds (files took 2.84 seconds to load)
185 examples, 0 failures

Coverage report generated for RSpec to /Users/dframpton/turing/2module/group_projects/adopt_dont_shop/c
overage. 1759 / 1759 LOC (100.0%) covered.
```